### PR TITLE
Fix verification email URLs to use environment-specific hosts

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,7 +1,7 @@
 class ReportMailer < ApplicationMailer
   def verification(report)
     @report = report
-    @verification_url = verify_report_url(token: report.verification_token, host: "redtape.la", protocol: "https")
+    @verification_url = verify_report_url(token: report.verification_token)
 
     mail(
       to: report.email,


### PR DESCRIPTION
Remove hardcoded host and protocol from verification email URL generation. Now uses config.action_mailer.default_url_options from each environment:
- Development: http://localhost:3000
- Production: https://redtape.la

This fixes the issue where verification emails in development pointed to the production domain instead of localhost, causing connection errors.