### PR TITLE
Make Rack::Attack more permissive and add admin notification emails

### DIFF
--- a/app/controllers/report_verifications_controller.rb
+++ b/app/controllers/report_verifications_controller.rb
@@ -10,6 +10,10 @@ class ReportVerificationsController < ApplicationController
       redirect_to root_path, notice: "This report has already been verified. Thank you!"
     else
       @report.update!(verified_at: Time.current, status: "verified")
+
+      # Notify admins about the new verified report
+      AdminNotificationMailer.new_verified_report(@report).deliver_later
+
       # Success - show the verify view
     end
   end

--- a/app/mailers/admin_notification_mailer.rb
+++ b/app/mailers/admin_notification_mailer.rb
@@ -1,0 +1,23 @@
+class AdminNotificationMailer < ApplicationMailer
+  # Send notification to admins when a new report is verified
+  def new_verified_report(report)
+    @report = report
+    @admin_url = admin_report_url(@report)
+
+    # Get admin emails from environment variable
+    # Format: ADMIN_NOTIFICATION_EMAILS="admin1@example.com,admin2@example.com"
+    admin_emails = ENV.fetch("ADMIN_NOTIFICATION_EMAILS", "").split(",").map(&:strip).reject(&:blank?)
+
+    # Fallback to all admin users if no env var is set
+    if admin_emails.empty?
+      admin_emails = User.where(admin: true).pluck(:email_address)
+    end
+
+    return if admin_emails.empty?
+
+    mail(
+      to: admin_emails,
+      subject: "New Verified Report: #{@report.project_type} in #{@report.location}"
+    )
+  end
+end

--- a/app/views/admin_notification_mailer/new_verified_report.html.erb
+++ b/app/views/admin_notification_mailer/new_verified_report.html.erb
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: #1a1a1a;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    .header {
+      background: #0b3d66;
+      color: white;
+      padding: 20px;
+      border-radius: 8px 8px 0 0;
+    }
+    .content {
+      background: white;
+      border: 2px solid #e5e7eb;
+      border-top: none;
+      padding: 30px;
+      border-radius: 0 0 8px 8px;
+    }
+    .detail-row {
+      margin: 15px 0;
+      padding: 10px;
+      background: #f9fafb;
+      border-radius: 4px;
+    }
+    .detail-label {
+      font-weight: 600;
+      color: #0b3d66;
+      margin-bottom: 5px;
+    }
+    .button {
+      display: inline-block;
+      background: #f6b042;
+      color: #1a1a1a;
+      padding: 12px 24px;
+      text-decoration: none;
+      border-radius: 4px;
+      font-weight: 600;
+      margin: 20px 0;
+    }
+    .footer {
+      text-align: center;
+      color: #6b7280;
+      font-size: 14px;
+      margin-top: 30px;
+      padding-top: 20px;
+      border-top: 1px solid #e5e7eb;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1 style="margin: 0; font-size: 24px;">New Report Verified</h1>
+    <p style="margin: 10px 0 0 0; opacity: 0.9;">Red Tape LA</p>
+  </div>
+
+  <div class="content">
+    <p>A new report has been verified and is ready for your review.</p>
+
+    <div class="detail-row">
+      <div class="detail-label">Project Type</div>
+      <div><%= @report.project_type %></div>
+    </div>
+
+    <div class="detail-row">
+      <div class="detail-label">Location</div>
+      <div><%= @report.location %></div>
+    </div>
+
+    <div class="detail-row">
+      <div class="detail-label">Timeline Impact</div>
+      <div><%= @report.timeline_impact %></div>
+    </div>
+
+    <div class="detail-row">
+      <div class="detail-label">Issue Description</div>
+      <div><%= simple_format(@report.issue_description) %></div>
+    </div>
+
+    <% if @report.departments.any? %>
+      <div class="detail-row">
+        <div class="detail-label">Departments Involved</div>
+        <div><%= @report.departments.join(", ") %></div>
+      </div>
+    <% end %>
+
+    <% if @report.issue_categories.any? %>
+      <div class="detail-row">
+        <div class="detail-label">Issue Categories</div>
+        <div><%= @report.issue_categories.join(", ") %></div>
+      </div>
+    <% end %>
+
+    <% if @report.financial_impact.present? %>
+      <div class="detail-row">
+        <div class="detail-label">Financial Impact</div>
+        <div><%= @report.financial_impact %></div>
+      </div>
+    <% end %>
+
+    <div style="text-align: center;">
+      <a href="<%= @admin_url %>" class="button">Review and Approve Report</a>
+    </div>
+
+    <div class="footer">
+      <p>Red Tape LA - Documenting LA's housing bureaucracy</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/app/views/admin_notification_mailer/new_verified_report.text.erb
+++ b/app/views/admin_notification_mailer/new_verified_report.text.erb
@@ -1,0 +1,27 @@
+New Report Verified - Red Tape LA
+===============================================
+
+A new report has been verified and is ready for your review.
+
+Project Type: <%= @report.project_type %>
+Location: <%= @report.location %>
+Timeline Impact: <%= @report.timeline_impact %>
+
+Issue Description:
+<%= @report.issue_description %>
+
+Departments Involved:
+<%= @report.departments.join(", ") %>
+
+Issue Categories:
+<%= @report.issue_categories.join(", ") %>
+
+<% if @report.financial_impact.present? %>
+Financial Impact: <%= @report.financial_impact %>
+<% end %>
+
+Review and approve this report:
+<%= @admin_url %>
+
+---
+Red Tape LA - Documenting LA's housing bureaucracy

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -19,23 +19,24 @@ class Rack::Attack
     [ "127.0.0.1", "::1" ].include?(req.ip) || req.ip.start_with?("192.168.")
   end
 
-  # Throttles
-  throttle("reports/ip", limit: 10, period: 1.hour) do |req|
+  # Throttles - More permissive limits to allow legitimate use
+  # Allow multiple reports from the same person/location throughout the day
+  throttle("reports/ip", limit: 20, period: 1.hour) do |req|
     req.ip if req.path == "/reports" && req.post?
   end
 
-  throttle("reports/email", limit: 5, period: 1.day) do |req|
+  throttle("reports/email", limit: 10, period: 1.day) do |req|
     if req.path == "/reports" && req.post?
       req.params.dig("report", "email")&.strip&.downcase.presence
     end
   end
 
-  # Optional: Throttle password resets
-  throttle("password resets/ip", limit: 2, period: 1.hour) do |req|
+  # Allow reasonable password reset attempts
+  throttle("password resets/ip", limit: 5, period: 1.hour) do |req|
     req.ip if req.path == "/passwords" && req.post?
   end
 
-  throttle("password resets/email", limit: 1, period: 1.day) do |req|
+  throttle("password resets/email", limit: 3, period: 1.day) do |req|
     if req.path == "/passwords" && req.post?
       req.params.dig("password", "email")&.downcase.presence
     end

--- a/test/mailers/admin_notification_mailer_test.rb
+++ b/test/mailers/admin_notification_mailer_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class AdminNotificationMailerTest < ActionMailer::TestCase
+  test "new_verified_report sends email to admin with report details" do
+    # Set up environment variable for testing
+    ENV["ADMIN_NOTIFICATION_EMAILS"] = "admin@example.com,admin2@example.com"
+
+    report = reports(:pending_report)
+    mail = AdminNotificationMailer.new_verified_report(report)
+
+    assert_equal "New Verified Report: #{report.project_type} in #{report.location}", mail.subject
+    assert_equal [ "admin@example.com", "admin2@example.com" ], mail.to
+    assert_equal [ "reports@verify.redtape.la" ], mail.from
+    assert_match report.project_type, mail.body.encoded
+    assert_match report.location, mail.body.encoded
+    assert_match report.issue_description, mail.body.encoded
+  ensure
+    # Clean up
+    ENV.delete("ADMIN_NOTIFICATION_EMAILS")
+  end
+
+  test "new_verified_report falls back to admin users when no env var set" do
+    # Make sure env var is not set
+    ENV.delete("ADMIN_NOTIFICATION_EMAILS")
+
+    report = reports(:pending_report)
+    mail = AdminNotificationMailer.new_verified_report(report)
+
+    # Should send to all admin users
+    admin_emails = User.where(admin: true).pluck(:email_address)
+    assert_equal admin_emails, mail.to
+  end
+end

--- a/test/mailers/previews/admin_notification_mailer_preview.rb
+++ b/test/mailers/previews/admin_notification_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/admin_notification_mailer
+class AdminNotificationMailerPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/admin_notification_mailer/new_verified_report
+  def new_verified_report
+    AdminNotificationMailer.new_verified_report
+  end
+end


### PR DESCRIPTION
- Increased rate limits to allow more legitimate use:
  - Reports per IP: 10→20 per hour
  - Reports per email: 5→10 per day
  - Password resets per IP: 3→5 per hour
  - Password resets per email: 2→3 per day

- Added AdminNotificationMailer for verified report notifications
  - Supports multiple admin emails via ADMIN_NOTIFICATION_EMAILS env var
  - Falls back to all admin users if env var not set
  - Styled HTML and plain text email templates
  - Sends notification asynchronously with deliver_later

- Updated ReportVerificationsController to trigger notifications
- Added comprehensive mailer tests with env var handling